### PR TITLE
Toyota EngineParser - FuelType 

### DIFF
--- a/common/domain/enum/FuelType.py
+++ b/common/domain/enum/FuelType.py
@@ -2,7 +2,9 @@ import enum
 
 
 class FuelType(enum.Enum):
-    GASOLINE = "Gas"
+    GASOLINE = "Gasoline"
     DIESEL = "Diesel"
     ELECTRIC = "Electric"
     HYBRID = "Hybrid"
+    FUEL_CELL = "Fuel Cell"
+    PLUG_IN_HYBRID = "Plug-in Hybrid"

--- a/transformer/transform/gm/parser/EngineParser.py
+++ b/transformer/transform/gm/parser/EngineParser.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Optional
 
 from common.domain.dto.AttributeDto import Drive, Engine
 from common.domain.dto.AttributeMetadata import AttributeMetadata
+from common.domain.enum.FuelType import FuelType
 from common.domain.enum.MetadataType import MetadataType
 from common.domain.enum.MetadataUnit import MetadataUnit
 from transformer.domain.attribute_set.AttributeSet import AttributeSet
@@ -10,7 +11,6 @@ from transformer.domain.attribute_set.metadata_updater.implementation.PriceUpdat
 from transformer.transform.AttributeParser import AttributeParser
 from transformer.transform.common import util
 from transformer.transform.gm.parser.LoggingTools import LoggingTools
-from common.domain.enum.FuelType import FuelType
 
 
 class EngineParser(AttributeParser):
@@ -47,6 +47,7 @@ class EngineParser(AttributeParser):
             fuelType = FuelType.ELECTRIC.value
         # no hybrid, GM has none currently (1-2023)
         else:
+            self.loggingTools.logInfo(parser=type(self), msg="Unable to infer fuel type from engine name: {engineName}")
             self.loggingTools.logtAttributeFailure(parser=type(self), modelIdentifier=modelIdentifier,
                                                    metadataType=MetadataType.ENGINE_FUEL_TYPE)
             return None

--- a/transformer/transform/gm/parser/LoggingTools.py
+++ b/transformer/transform/gm/parser/LoggingTools.py
@@ -33,6 +33,13 @@ class LoggingTools:
         logging.info(f"{transformer.__name__} - {parser.__name__} ")
         logging.debug("Parser Failure:\n", exc_info=exception)
 
+    def logInfo(self, parser: type, msg: str, modelIdentifier: str = None):
+        if modelIdentifier:
+            prefix = f"{parser.__name__} : {modelIdentifier} INFO"
+        else:
+            prefix = f"{parser.__name__} INFO"
+        self.log.info(f"{prefix}: {msg}")
+
     def getModelIdentifier(self, dataDict: Dict) -> str:
         """
         Return an identifier that can be used for logging (optimally human-readable,

--- a/transformer/transform/gm/parser/test_EngineParser.py
+++ b/transformer/transform/gm/parser/test_EngineParser.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from common.domain.dto.AttributeDto import Engine
 from common.domain.dto.AttributeMetadata import AttributeMetadata
+from common.domain.enum.FuelType import FuelType
 from common.domain.enum.MetadataType import MetadataType
 from common.domain.enum.MetadataUnit import MetadataUnit
 from transformer.transform.gm.parser.EngineParser import EngineParser
@@ -45,11 +46,11 @@ class TestEngineParser(TestCase):
         foundPower = self.parser._getPower(engineDict=engineDict, modelIdentifier="test")
         self.assertEqual(expectedPower, foundPower, testIdentifer)
 
-    @parameterized.expand([({"primaryName": "Duramax 3.0L"}, "Gas", "gas #.#L"),
-                           ({"primaryName": "Duramax 3L"}, "Gas", "gas #L"),
-                           ({"primaryName": "Duramax 3L DiEsEl"}, "Diesel", "diesel #L"),
+    @parameterized.expand([({"primaryName": "Duramax 3.0L"}, FuelType.GASOLINE.value, "gas #.#L"),
+                           ({"primaryName": "Duramax 3L"}, FuelType.GASOLINE.value, "gas #L"),
+                           ({"primaryName": "Duramax 3L DiEsEl"}, FuelType.DIESEL.value, "diesel #L"),
                            ({"primaryName": "Engine, standard"}, None, "Neither gas, diesel nor electric"),
-                           ({"primaryName": "Engine, standard", "description": "ElEcTrIc Drive."}, "Electric",
+                           ({"primaryName": "Engine, standard", "description": "ElEcTrIc Drive."}, FuelType.ELECTRIC.value,
                             "Neither gas, diesel nor electric"),
                            ({"primaryName": None, "description": None}, None,
                             "Keys null"),
@@ -82,7 +83,7 @@ class TestEngineParser(TestCase):
                  metadata=[AttributeMetadata(metadataType=MetadataType.COMMON_MSRP, value=3_000,
                                              unit=MetadataUnit.DOLLARS),
                            AttributeMetadata(metadataType=MetadataType.ENGINE_FUEL_TYPE,
-                                             value="Gas"),
+                                             value=FuelType.GASOLINE.value),
                            AttributeMetadata(metadataType=MetadataType.ENGINE_HORSEPOWER, value=300,
                                              unit=MetadataUnit.HORSEPOWER)
                            ])], "Title all attributes"),
@@ -95,7 +96,7 @@ class TestEngineParser(TestCase):
     ])
     def test_parseSingleEngine(self, dataDict: Dict, expectedEngines, testIdentifier: str):
         foundEngines = self.parser.parse(dataDict)
-        self.assertEqual(len(expectedEngines), len(foundEngines))
+        self.assertEqual(len(expectedEngines), len(foundEngines), testIdentifier)
         # make test insensitive to order of engines
         enginesByTitle = lambda engines: {engine.title: engine for engine in engines}
         expectedEnginesByTitle = enginesByTitle(expectedEngines)

--- a/transformer/transform/toyota/parser/test_EngineParser.py
+++ b/transformer/transform/toyota/parser/test_EngineParser.py
@@ -1,12 +1,16 @@
 import logging
+from typing import Optional
 from unittest import TestCase
+
+from parameterized import parameterized
 
 from common.domain.dto.AttributeDto import Engine
 from common.domain.dto.AttributeMetadata import AttributeMetadata
+from common.domain.enum.FuelType import FuelType
 from common.domain.enum.MetadataType import MetadataType
 from common.domain.enum.MetadataUnit import MetadataUnit
-from transformer.transform.toyota.parser.LoggingTools import LoggingTools
 from transformer.transform.toyota.parser.EngineParser import EngineParser
+from transformer.transform.toyota.parser.LoggingTools import LoggingTools
 
 
 class TestEngineParser(TestCase):
@@ -15,41 +19,54 @@ class TestEngineParser(TestCase):
         self.loggingTools = LoggingTools(logging.getLogger())
         self.engineParser = EngineParser(self.loggingTools)
 
-
-    noTitle = {"engine" : {} }
+    noTitle = {"engine": {}}
     noTitleEngine = None
+
+    @parameterized.expand([("Battery Electric", FuelType.ELECTRIC.value, "Electric"),
+                           ("Fuel Cell", FuelType.FUEL_CELL.value, "Fuel Cell"),
+                           ("Gas", FuelType.GASOLINE.value, "Gasoline"),
+                           ("Plug-in Hybrid", FuelType.PLUG_IN_HYBRID.value, "PHEV"),
+                           ("Hybrid", FuelType.HYBRID.value, "Hybrid")])
+    def test_getFuelTypeRecognizedTypes(self, fuelTypeStr: str, expectedFuelType: Optional[str], testIdentifier: str):
+        modelJson = {'attributes':{'fueltype':{'value' : fuelTypeStr}}}
+        foundMetadata = self.engineParser._getFuelType(modelJson)
+        self.assertEqual(expectedFuelType, foundMetadata.value, testIdentifier)
+
+    def test_getFuelTypeUnrecognizedType(self):
+        modelJson = {'attributes': {'fueltype': {'value': "Nuclear Fussion"}}}
+        self.assertIsNone(self.engineParser._getFuelType(modelJson))
 
     def test_parseModelNoTitle(self):
         found = self.engineParser._parseModel(self.noTitle)
         self.assertIsNone(found)
 
-    onlyTitle = {"engine" : {"title" : "1ZZ-FE" } }
+    onlyTitle = {"engine": {"title": "1ZZ-FE"}}
     onlyTitleEngine = Engine("1ZZ-FE")
 
     def test_parseModelOnlyTitle(self):
         found = self.engineParser._parseModel(self.onlyTitle)
         self.onlyTitleEngine._assertStrictEq(found)
 
-    titleNoneMetadata = {"engine" : {"title" : "2JZ-GTE",
-                                        "attributes" : {
-                                            "fueltype" : {"value" : None},
-                                            "horsepower" : {"value" : None},
-                                            "cylinders" : {"value" : None}
-                                        } } }
+    titleNoneMetadata = {"engine": {"title": "2JZ-GTE",
+                                    "attributes": {
+                                        "fueltype": {"value": None},
+                                        "horsepower": {"value": None},
+                                        "cylinders": {"value": None}
+                                    }}}
     titleNoneMetadataEngine = Engine("2JZ-GTE")
 
     def test_parseModelTitleNoneMetadata(self):
         found = self.engineParser._parseModel(self.titleNoneMetadata)
         self.titleNoneMetadataEngine._assertStrictEq(found)
 
-    titleFullMetadata = {"engine" : {"title" : "2AZ-FE"},
-                            "attributes" : {
-                                            "fueltype" : {"value" : "Gas"},
-                                            "horsepower" : {"value" : 145},
-                                            "cylinders" : {"value" : 4}
-                                        } }
+    titleFullMetadata = {"engine": {"title": "2AZ-FE"},
+                         "attributes": {
+                             "fueltype": {"value": "Gas"},
+                             "horsepower": {"value": 145},
+                             "cylinders": {"value": 4}
+                         }}
     titleFullMetadataEngine = Engine(title="2AZ-FE", metadata=[
-        AttributeMetadata(metadataType=MetadataType.ENGINE_FUEL_TYPE, value="Gas"),
+        AttributeMetadata(metadataType=MetadataType.ENGINE_FUEL_TYPE, value=FuelType.GASOLINE.value),
         AttributeMetadata(metadataType=MetadataType.ENGINE_HORSEPOWER, value=145, unit=MetadataUnit.HORSEPOWER),
         AttributeMetadata(metadataType=MetadataType.ENGINE_CYLINDERS, value=4)
     ])
@@ -59,16 +76,12 @@ class TestEngineParser(TestCase):
         self.titleFullMetadataEngine._assertStrictEq(found)
 
     def test_parse(self):
-        jsonData = {"model" : [self.noTitle, self.onlyTitle, self.titleFullMetadata]}
+        jsonData = {"model": [self.noTitle, self.onlyTitle, self.titleFullMetadata]}
         foundEngines = self.engineParser.parse(jsonData)
-        self.assertEqual(2, len(foundEngines), "num engines found" )
-        expectedEnginesByTitle = { engine.title : engine for engine in [self.onlyTitleEngine, self.titleFullMetadataEngine] }
+        self.assertEqual(2, len(foundEngines), "num engines found")
+        expectedEnginesByTitle = {engine.title: engine for engine in
+                                  [self.onlyTitleEngine, self.titleFullMetadataEngine]}
         for foundEngine in foundEngines:
-            self.assertIsNotNone(expectedEngine := expectedEnginesByTitle.get(foundEngine.title), f"incorrect title {foundEngine}")
+            self.assertIsNotNone(expectedEngine := expectedEnginesByTitle.get(foundEngine.title),
+                                 f"incorrect title {foundEngine}")
             expectedEngine._assertStrictEq(foundEngine)
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #5
* Modified to map parsed fuel types to FuelType Enums
* Added tests to toyota EngineParser
* Made minor changes to GM EngineParser to improve logging